### PR TITLE
Change READMEs to new GitHub markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ Welcome to the example application used in AngularDart's
 You can run a [hosted copy](http://angular-examples.github.io/quickstart) of this sample. Or run your own copy:
 
 1. Clone or [download][] this repo.
-   [download]: //github.com/angular-examples/quickstart/archive/master.zip
+
 2. Get the dependencies:
 
-  `pub get`
+   `pub get`
+  
 3. Launch a development server:
 
-  `pub serve`
+   `pub serve`
+  
 4. Open a browser to `http://localhost:8080`.<br/>
   In Dartium, you'll see the app right away. In other modern browsers,
   you'll have to wait a bit while pub converts the app.
@@ -28,3 +30,5 @@ You can run a [hosted copy](http://angular-examples.github.io/quickstart) of thi
 [dart-doc-syncer](//github.com/angular/dart-doc-syncer) tool.
 If you find a problem with this sample's code, please open an
 [issue](//github.com/dart-lang/site-webdev/issues/new?labels=example&title=%5BAngular%5D%5Bexample%5D%20quickstart%3A%20).
+
+[download]: //github.com/angular-examples/quickstart/archive/master.zip


### PR DESCRIPTION
We need to fix this in the actual source, of course.

See:

* https://githubengineering.com/a-formal-spec-for-github-markdown/
* https://github.com/github/markup/issues/1018