### PR TITLE
Updated the dependencies to latest alpha release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,14 +3,14 @@ description: A web app that uses AngularDart
 version: 0.0.1
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  angular: ^5.0.0
+  angular: ^6.0.0-alpha
 
 dev_dependencies:
-  angular_test: ^2.0.0
-  build_runner: ^1.0.0
-  build_test: ^0.10.2
-  build_web_compilers: ^0.4.0
-  test: ^1.0.0
+  angular_test: ^2.3.1
+  build_runner: ^1.5.1
+  build_test: ^0.10.8
+  build_web_compilers: ^2.1.0
+  test: ^1.6.4


### PR DESCRIPTION
pubspec.yaml
Updated the dependencies to latest alpha release (since this project is linked from the https://angulardart.dev/guide/setup#create-a-starter-project)

Error while running with the current release of angular dart, so update the quickstart project to reflect to the latest ones.

webdev serve
webdev could not run for this project.
The `build_runner` version – 1.2.3 – is not within the allowed constraint – >=1.5.0 <2.0.0.The `build_web_compilers` version – 0.4.4+3 – is not within the allowed constraint – >=1.2.0 <3.0.0.